### PR TITLE
Update PDF-QA app.py

### DIFF
--- a/pdf-qa/app.py
+++ b/pdf-qa/app.py
@@ -39,8 +39,13 @@ def process_file(file: AskFileResponse):
     elif file.type == "application/pdf":
         Loader = PyPDFLoader
 
-    with tempfile.NamedTemporaryFile() as tempfile:
-        tempfile.write(file.content)
+    with tempfile.NamedTemporaryFile(mode='w', delete=False) as tempfile:
+        if file.type == "text/plain":
+            tempfile.write(file.content)
+        elif file.type == "application/pdf":
+            with open(tempfile.name, 'wb') as f:  
+                f.write(file.content)
+                
         loader = Loader(tempfile.name)
         documents = loader.load()
         docs = text_splitter.split_documents(documents)


### PR DESCRIPTION
fix Permission denied on windows at "with tempfile.NamedTemporaryFile"

fix  TypeError:  write() argument must be str, not bytes when Loader is PyPDFLoader at "tempfile.write(file.content)"