### PR TITLE
Fix the null bug

### DIFF
--- a/pinecone/app.py
+++ b/pinecone/app.py
@@ -58,6 +58,7 @@ async def main(message: cl.Message):
     cb = cl.AsyncLangchainCallbackHandler()
     answer="\n N/A" 
     source_documents=None
+    # check for null values
     if chain:
        res = await chain.acall(message.content, callbacks=[cb])
        answer = res["answer"]

--- a/pinecone/app.py
+++ b/pinecone/app.py
@@ -56,10 +56,14 @@ async def main(message: cl.Message):
     chain = cl.user_session.get("chain")  # type: ConversationalRetrievalChain
 
     cb = cl.AsyncLangchainCallbackHandler()
-
-    res = await chain.acall(message.content, callbacks=[cb])
-    answer = res["answer"]
-    source_documents = res["source_documents"]  # type: List[Document]
+    answer="\n N/A" 
+    source_documents=None
+    if chain:
+       res = await chain.acall(message.content, callbacks=[cb])
+       answer = res["answer"]
+       source_documents = res["source_documents"]  # type: List[Document]
+    else: 
+       answer += "\nNo chain found"
 
     text_elements = []  # type: List[cl.Text]
 


### PR DESCRIPTION
in the Chainlit example for Pinecone the program crashed because we weren't checking if chain is null. Fixed this.