### PR TITLE
docs: pip install autogen -> pip install pyautogen

### DIFF
--- a/pyautogen/README.md
+++ b/pyautogen/README.md
@@ -24,7 +24,7 @@ source venv/bin/activate
 2. Install the required dependencies:
         
 ```shell 
-pip install chainlit autogen
+pip install chainlit pyautogen
 ```
 
 3. Copy the `.env.sample` file to a new `.env` file and replace the `api_key` value with your own OpenAI API key.


### PR DESCRIPTION
This PR corrects the package name in our installation instructions of README from `pip install chainlit autogen` to `pip install chainlit pyautogen`.