### PR TITLE
Add "langchain-community" in requirements.txt

### DIFF
--- a/chroma-qa-chat/requirements.txt
+++ b/chroma-qa-chat/requirements.txt
@@ -1,4 +1,5 @@
 langchain
+langchain-community
 chainlit
 langchain_openai
 openai


### PR DESCRIPTION
Fix this error when running example

ModuleNotFoundError: No module named 'langchain_community'

<img width="801" alt="Screenshot 2024-05-19 at 2 49 07 PM" src="https://github.com/Chainlit/cookbook/assets/3505778/92f503c6-2342-450f-a616-5c833c2ce2f5">
