### PR TITLE
Updates app.py in anthropic-chat

### DIFF
--- a/anthropic-chat/app.py
+++ b/anthropic-chat/app.py
@@ -2,7 +2,7 @@ import os
 import anthropic
 import chainlit as cl
 
-c = anthropic.AsyncAnthropic(api_key=os.environ["ANTHROPIC_API_KEY"])
+c = anthropic.AsyncAnthropic(api_key=os.getenv["ANTHROPIC_API_KEY"])
 
 
 @cl.on_chat_start
@@ -18,23 +18,22 @@ async def call_claude(query: str):
 
     prompt = f"{prompt_history}{anthropic.HUMAN_PROMPT}{query}{anthropic.AI_PROMPT}"
 
-    settings = {
-        "stop_sequences": [anthropic.HUMAN_PROMPT],
-        "max_tokens_to_sample": 1000,
-        "model": "claude-2.0",
-    }
-    
     msg = cl.Message(content="", author="Claude")
 
-    stream = await c.completions.create(
-        prompt=prompt,
+    stream = await c.messages.create(
+        model="claude-2.0",
+        messages=[
+            {"role": "user", "content":prompt}
+        ],
+        max_tokens=1000,
+        stop_sequences=[anthropic.HUMAN_PROMPT],
         stream=True,
-        **settings,
     )
 
     async for data in stream:
-        token = data.completion
-        await msg.stream_token(token)
+        if data.type=="content_block_delta":
+            token = data.delta.text
+            await msg.stream_token(token)
 
     await msg.send()
     cl.user_session.set("prompt_history", prompt + msg.content)


### PR DESCRIPTION
The app.py in anthropic-chat uses the legacy Text Completions API, which results in errors. The Anthropic Documentation mentions using the Messages API (https://github.com/anthropics/anthropic-sdk-python/blob/main/src/anthropic/resources/completions.py#L61). I've updated the file to use Messages API and the token handling.