### PR TITLE
Add a sample of two-way window messaging

### DIFF
--- a/window-message/README.md
+++ b/window-message/README.md
@@ -1,0 +1,15 @@
+# Window Message with Chainlit
+
+Run the chainlit application on port 8000:
+
+```shell
+chainlit run app.py -h -c --port 8000
+```
+
+Then open `frontend\dist\index.html` in your browser, which includes Chainlit inside an iframe.
+
+Click on the `Send message to iframe` button to send a message to the server, handled using `@cl.on_window_message`.
+
+The server will send back a message to the parent window using `cl.send_window_message` when receiving either a window message or a regular message.
+
+The last message received by the window is displayed above the button.

--- a/window-message/app.py
+++ b/window-message/app.py
@@ -1,0 +1,12 @@
+import chainlit as cl
+
+@cl.on_window_message
+async def window_message(message: str):
+    if message.startswith("Client: "):
+        await cl.Message(content=f"Window message received: {message}").send()
+        cl.send_window_message(f"Server: Window message received: {message}")
+
+@cl.on_message
+async def on_message(msg: cl.Message):
+    await cl.Message(content=f"Normal message received: {msg.content}").send()
+    cl.send_window_message(f"Server: Normal message received: {msg.content}")

--- a/window-message/app.py
+++ b/window-message/app.py
@@ -4,9 +4,9 @@ import chainlit as cl
 async def window_message(message: str):
     if message.startswith("Client: "):
         await cl.Message(content=f"Window message received: {message}").send()
-        cl.send_window_message(f"Server: Window message received: {message}")
+        await cl.send_window_message(f"Server: Window message received: {message}")
 
 @cl.on_message
 async def on_message(msg: cl.Message):
     await cl.Message(content=f"Normal message received: {msg.content}").send()
-    cl.send_window_message(f"Server: Normal message received: {msg.content}")
+    await cl.send_window_message(f"Server: Normal message received: {msg.content}")

--- a/window-message/chainlit.md
+++ b/window-message/chainlit.md
@@ -1,0 +1,14 @@
+# Welcome to Chainlit! 🚀🤖
+
+Hi there, Developer! 👋 We're excited to have you on board. Chainlit is a powerful tool designed to help you prototype, debug and share applications built on top of LLMs.
+
+## Useful Links 🔗
+
+- **Documentation:** Get started with our comprehensive [Chainlit Documentation](https://docs.chainlit.io) 📚
+- **Discord Community:** Join our friendly [Chainlit Discord](https://discord.gg/k73SQ3FyUh) to ask questions, share your projects, and connect with other developers! 💬
+
+We can't wait to see what you create with Chainlit! Happy coding! 💻😊
+
+## Welcome screen
+
+To modify the welcome screen, edit the `chainlit.md` file at the root of your project. If you do not want a welcome screen, just leave this file empty.

--- a/window-message/frontend/dist/index.html
+++ b/window-message/frontend/dist/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="UTF-8" />
+</head>
+
+<body>
+  <h1>Chainlit Window Message Test</h1>
+  <iframe src="http://127.0.0.1:8000/" id="the-frame" data-cy="the-frame" width="100%" height="500px"></iframe>
+  <div id="message">No message received</div>
+  <button onclick="postMessageToIframe()">Send message to iframe</button>
+  <script>
+      window.addEventListener('message', function(event) {
+          if (event.data.startsWith("Server: ")) {
+              document.getElementById('message').innerText = event.data;
+          }
+      });
+
+      function postMessageToIframe() {
+          const iframe = document.getElementById('the-frame');
+          iframe.contentWindow.postMessage('Client: Hello from parent window', '*');
+      }
+  </script>
+</body>
+
+</html>


### PR DESCRIPTION
This adds a sample of the new window messaging feature introduced by https://github.com/Chainlit/chainlit/pull/1469.
Documentation at https://github.com/Chainlit/docs/pull/194.