### PR TITLE
websocket fixes: add requirement and fix arity issue

### DIFF
--- a/realtime-assistant/realtime/__init__.py
+++ b/realtime-assistant/realtime/__init__.py
@@ -93,7 +93,7 @@ class RealtimeAPI(RealtimeEventHandler):
     async def connect(self, model='gpt-4o-realtime-preview-2024-10-01'):
         if self.is_connected():
             raise Exception("Already connected")
-        self.ws = await websockets.connect(f"{self.url}?model={model}", extra_headers={
+        self.ws = await websockets.connect(f"{self.url}?model={model}", additional_headers={
             'Authorization': f'Bearer {self.api_key}',
             'OpenAI-Beta': 'realtime=v1'
         })

--- a/realtime-assistant/requirements.txt
+++ b/realtime-assistant/requirements.txt
@@ -1,4 +1,5 @@
-chainlit==1.3.0rc1
+chainlit==2.0rc0
 openai
 yfinance
 plotly
+websockets==14.1


### PR DESCRIPTION
Looks to be a couple small, dependency issues

- missing websocket requirement cause `chainlit run app.py` to fail
- websocket connect function takes `additional_headers` not `extra_..`.  Error appears on connection to OpenAI

Tested with release tarball `chainlit==2.0rc0`

