### PR TITLE
Fix the issue "This site can't be reached" when launching the app.

### DIFF
--- a/aws-ecs-deployment/Dockerfile
+++ b/aws-ecs-deployment/Dockerfile
@@ -1,8 +1,8 @@
 # Use an appropriate base image, e.g., python:3.10-slim
-# FROM --platform=linux/amd64 python:3.9-slim
-FROM python:3.9-slim
+FROM --platform=linux/amd64 python:3.9-slim
+
 # Set environment variables (e.g., set Python to run in unbuffered mode)
-ENV PYTHONUNBUFFERED=1 
+ENV PYTHONUNBUFFERED=1
 
 # Set the working directory
 WORKDIR /app

--- a/aws-ecs-deployment/Dockerfile
+++ b/aws-ecs-deployment/Dockerfile
@@ -1,8 +1,8 @@
 # Use an appropriate base image, e.g., python:3.10-slim
-FROM --platform=linux/amd64 python:3.9-slim
-
+# FROM --platform=linux/amd64 python:3.9-slim
+FROM python:3.9-slim
 # Set environment variables (e.g., set Python to run in unbuffered mode)
-ENV PYTHONUNBUFFERED 1
+ENV PYTHONUNBUFFERED=1 
 
 # Set the working directory
 WORKDIR /app
@@ -17,4 +17,4 @@ COPY . /app/
 
 EXPOSE 8080
 
-CMD ["python", "-m", "chainlit", "run", "app.py", "-h", "--port", "8080"]
+CMD ["python", "-m", "chainlit", "run", "app.py", "-h", "--host", "0.0.0.0", "--port", "8080"]

--- a/aws-ecs-deployment/README.md
+++ b/aws-ecs-deployment/README.md
@@ -42,7 +42,7 @@ Create a `Dockerfile` with the following content:
 # Use an appropriate base image, e.g., python:3.10-slim
 FROM python:3.10-slim
 # Set environment variables
-ENV PYTHONUNBUFFERED 1
+ENV PYTHONUNBUFFERED=1
 # Set the working directory
 WORKDIR /app
 # Install dependencies
@@ -53,7 +53,7 @@ COPY . /app/
 # Expose the port the app runs on
 EXPOSE 8080
 # Command to run the app
-CMD ["python", "-m", "chainlit", "run", "app.py", "-h", "--port", "8080"]
+CMD ["python", "-m", "chainlit", "run", "app.py", "-h", "--host", "0.0.0.0", "--port", "8080"]
 ```
 
 Note: If you’re on Mac M1, use `FROM --platform=linux/amd64 python:3.9-slim` as the first line.


### PR DESCRIPTION
Dear Chainlit team,
While adhering to the instructions outlined in **Step 4: Build and Run Locally** of the [cookbook](https://github.com/Chainlit/cookbook/tree/main)/[aws-ecs-deployment](https://github.com/Chainlit/cookbook/tree/main/aws-ecs-deployment), I encountered the "**This site can't be reached**" error upon attempting to launch the application locally.
![app_nok](https://github.com/user-attachments/assets/000ed564-e5e2-4da4-a79e-75468ce79fcf)
I would like to suggest a minor modification to the 'Dockerfile' to resolve this issue. The default command in the 'Dockerfile' should include the option **--host 0.0.0.0** as follows:
```
CMD ["python", "-m", "chainlit", "run", "app.py", "-h", "--host", "0.0.0.0", "--port", "8080"]
```
Through this modification, I was able to successfully initiate the application.
![app_ok](https://github.com/user-attachments/assets/a166a2c0-f99f-47ed-b753-62cfb2525f77)
I also change 'ENV PYTHONUNBUFFERED 1' to '**ENV PYTHONUNBUFFERED=1**' in the Dockerfile to resolve the 'LegacyKeyValueFormat' warning that occurs during the Docker image build process.