### PR TITLE
Update realtime example

### DIFF
--- a/realtime-assistant/.env.example
+++ b/realtime-assistant/.env.example
@@ -1,2 +1,7 @@
-OPENAI_API_KEY=your-openai-api-key
+OPENAI_API_KEY=api-key
 
+# OPENAI_BASE_WSS_URL=wss://api.ai.it.cornell.edu
+OPENAI_BASE_WSS_URL=wss://litellm-dev.lcmain.aaii.cucloud.net
+
+OPENAI_REALTIME_MODEL=openai.gpt-realtime-mini
+OPENAI_TRANSCRIPTION_MODEL=openai.whisper

--- a/realtime-assistant/.env.example
+++ b/realtime-assistant/.env.example
@@ -1,7 +1,4 @@
-OPENAI_API_KEY=api-key
-
-# OPENAI_BASE_WSS_URL=wss://api.ai.it.cornell.edu
-OPENAI_BASE_WSS_URL=wss://litellm-dev.lcmain.aaii.cucloud.net
-
-OPENAI_REALTIME_MODEL=openai.gpt-realtime-mini
-OPENAI_TRANSCRIPTION_MODEL=openai.whisper
+OPENAI_API_KEY=your-openai-api-key
+OPENAI_BASE_WSS_URL=wss://api.openai.com
+OPENAI_REALTIME_MODEL=gpt-4o-realtime-preview-2024-12-17
+OPENAI_TRANSCRIPTION_MODEL=whisper-1

--- a/realtime-assistant/realtime/__init__.py
+++ b/realtime-assistant/realtime/__init__.py
@@ -81,7 +81,7 @@ class RealtimeEventHandler:
 class RealtimeAPI(RealtimeEventHandler):
     def __init__(self, url=None, api_key=None):
         super().__init__()
-        self.default_url = "wss://api.openai.com/v1/realtime"
+        self.default_url = f"{os.getenv('OPENAI_BASE_WSS_URL')}/v1/realtime"
         self.url = url or self.default_url
         self.api_key = api_key or os.getenv("OPENAI_API_KEY")
         self.ws = None
@@ -92,7 +92,7 @@ class RealtimeAPI(RealtimeEventHandler):
     def log(self, *args):
         logger.debug(f"[Websocket/{datetime.utcnow().isoformat()}]", *args)
 
-    async def connect(self, model='gpt-4o-realtime-preview-2024-12-17'):
+    async def connect(self, model=os.getenv("OPENAI_REALTIME_MODEL")):
         if self.is_connected():
             raise Exception("Already connected")
         self.ws = await websockets.connect(f"{self.url}?model={model}", additional_headers={
@@ -386,7 +386,7 @@ class RealtimeClient(RealtimeEventHandler):
             "voice": "shimmer",
             "input_audio_format": "pcm16",
             "output_audio_format": "pcm16",
-            "input_audio_transcription": {"model": "whisper-1"},
+            "input_audio_transcription": {"model": f"{os.getenv('OPENAI_TRANSCRIPTION_MODEL')}"},
             "turn_detection": {"type": "server_vad"},
             "tools": [],
             "tool_choice": "auto",
@@ -394,7 +394,7 @@ class RealtimeClient(RealtimeEventHandler):
             "max_response_output_tokens": 4096,
         }
         self.session_config = {}
-        self.transcription_models = [{"model": "whisper-1"}]
+        self.transcription_models = [{"model": f"{os.getenv('OPENAI_TRANSCRIPTION_MODEL')}"}]
         self.default_server_vad_config = {
             "type": "server_vad",
             "threshold": 0.5,

--- a/realtime-assistant/requirements.txt
+++ b/realtime-assistant/requirements.txt
@@ -1,4 +1,4 @@
-chainlit
+chainlit<2.7
 openai
 yfinance
 plotly


### PR DESCRIPTION
Realtime example does not seem to work anymore as-is past chainlit 2.6.9, so locking version to <2.7 in requirements.txt

Also, I parameterized a few items in the realtime code and added them to .env.example. This allows for easily changing the model names used and WSS base url in case user would like to use LiteLLM proxy or similar instead of OpenAI API directly.